### PR TITLE
Cache policy impovements - add failure call in serverIfFailReadFromCahce

### DIFF
--- a/CoreNetKit/Core/ServerPart/BaseCoreServerRequest.swift
+++ b/CoreNetKit/Core/ServerPart/BaseCoreServerRequest.swift
@@ -234,8 +234,16 @@ extension BaseCoreServerRequest {
                 self.log(afResponse)
                 var response: CoreServerResponse = BaseCoreServerResponse(dataResponse: afResponse, dataResult: .success(afResponse.data, false), errorMapper: self.errorMapper)
 
-                // If response has flag NotModified in all cases or InternetConnection was failed in case of serverIfFailReadFromCahce it is necessary condition to read frowm cache
-                let isNeedsToReadCache = response.isNotModified || response.isConnectionFailed && self.cachePolicy == .serverIfFailReadFromCahce
+                // If response has flag NotModified in all cases we need to load cache
+                var isNeedsToReadCache = response.isNotModified
+
+                // If cache policy is serverIfFailReadFromCahce and request fails we need to:
+                // 1. send failure completion
+                // 2. try to load response from cache
+                if self.cachePolicy == .serverIfFailReadFromCahce, case ResponseResult.failure = response.result {
+                    isNeedsToReadCache = true
+                    completion(response)
+                }
 
                 if isNeedsToReadCache,
                     let guardRequest = request.request, let guardedAdapter = self.cacheAdapter {


### PR DESCRIPTION
Now if cache policy is serverIfFailReadFromCahce firstly we will receive failure call-back and then will try to get data from cache.